### PR TITLE
Linux fixes for serialport command + module loading tweaks

### DIFF
--- a/js/commands/SerialCommand.js
+++ b/js/commands/SerialCommand.js
@@ -97,7 +97,9 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
                 var port = ports[i];
 
                 //not trying to be secure here, just trying to be helpful.
-                if (port.manufacturer.indexOf("Spark") >= 0) {
+                if ( (port.manufacturer && port.manufacturer.indexOf("Spark") >= 0) ||
+                    (port.pnpId && port.pnpId.indexOf("Spark_Core") >= 0)
+                ) {
                     cores.push(port);
                 }
             }

--- a/js/lib/interpreter.js
+++ b/js/lib/interpreter.js
@@ -72,7 +72,10 @@ Interpreter.prototype = {
         this._commands = [];
         this.commandsByName = {};
 
-        var files = fs.readdirSync(settings.commandPath);
+        var files = fs.readdirSync(settings.commandPath).filter(function(file){
+            return file.indexOf('.') !== 0; // Ignore hidden files (Such as .swp files)
+        });
+
         for (var i = 0; i < files.length; i++) {
             var cmdPath = path.join(settings.commandPath, files[i]);
             try {
@@ -100,3 +103,4 @@ Interpreter.prototype = {
     _: null
 };
 module.exports = Interpreter;
+


### PR DESCRIPTION
In linux, port.manufacturer is likely to be undefined, so we need to check for that. port.pnpId will contain a string similar to:

"usb-Spark_Devices_Spark_Core_with_WiFi_XXXXXXXXXX" which we can use to find Spark Cores

This commit also includes a fix to not to try to load modules from hidden files. (Such as .swp files)
