### PR TITLE
removed core-id from 'cloud compile' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Getting Started / Documentation
 
 ###spark cloud compile
 
-    > spark cloud compile 0123456789ABCDEFGHI my_application.ino
-    > spark cloud compile 0123456789ABCDEFGHI /projects/big_app/src
+    > spark cloud compile my_application.ino
+    > spark cloud compile /projects/big_app/src
 
   Create and download a firmware binary, by cloud compiling a source file, or a directory of source files
 


### PR DESCRIPTION
The core-id is not required for compiling
