### PR TITLE
To support event streams using 'mine'

### DIFF
--- a/js/lib/ApiClient.js
+++ b/js/lib/ApiClient.js
@@ -527,7 +527,7 @@ ApiClient.prototype = {
             url = "/v1/devices/" + coreId + "/events";
         }
 
-        if (eventName) {
+        if (eventName != "#") {
             url += "/" + eventName;
         }
 


### PR DESCRIPTION
Tested out \* and it seems to be a command on MS-DOS which didn't allow it to be read. 

When i used \* as the eventName, `spark subscribe *`, the eventName was read as `undefined`.

So i would be proposing `spark subscribe # mine` for event streams of the user.
