### PR TITLE
add sudo to npm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installing
   Next, open a command prompt or terminal, and install by typing:
 
 ```sh 
-$ npm install -g spark-cli
+$ sudo npm install -g spark-cli
 $ spark cloud login
 ```
 


### PR DESCRIPTION
If you install `node.js` for all users, you have to `sudo` to install `spark-cli` on OSX, at least
