### PR TITLE
Update usage of "spark flash"

### DIFF
--- a/js/mappings.json
+++ b/js/mappings.json
@@ -106,9 +106,10 @@
     "flash": {
         "maps": [ "flash", "*" ],
         "usage": [
-            "spark flash core_id firmware.bin [--usb]",
-            "spark flash core_id source_folder [--usb]",
-            "spark flash core_id file1.ino file2.cpp file2.h file3.cpp [--usb]"
+            "spark flash core_id firmware.bin",
+            "spark flash --usb firmware.bin"
+            "spark flash core_id source_folder",
+            "spark flash core_id file1.ino file2.cpp file2.h file3.cpp"
         ],
         "does": [
             "flash remotely pushes a compiled firmware binary to one of your cores over the air, or directly",


### PR DESCRIPTION
1.) Removed `[--usb]` for `spark flash core_if list-of-files` and `spark flash directory` as they are not valid.

2.) Changed the instructions to flash via `--usb` as a separate command as `spark flash core_id firmware.bin [--usb]` is too vague.
