### PR TITLE
update serialport dependency

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -18,11 +18,9 @@
         "hogan.js": "~2.0.0",
         "moment": "*",
         "request": "*",
-        "serialport": "1.4.0",
+        "serialport": "1.4.5",
         "when": "*",
         "xtend": "*"
     },
     "preferGlobal": true
 }
-
-


### PR DESCRIPTION
update `serialport` dependency to `1.4.5` to prevent failing build on 64-bit OS X with `node 0.11.13`
more info at [github.com/voodootikigod/node-serialport/pull/359](https://github.com/voodootikigod/node-serialport/pull/359)
