### PR TITLE
check for spark vendorid in findcores

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -1,6 +1,8 @@
 changelog
 =========
 
+10/07/2014 - 0.4.2  - test for spark vendorid in findcores
+
 09/10/2014 - 0.4.1  - new tinker!  Version 10 -- oops.
 09/10/2014 - 0.4.0  - new tinker!  Version 10
 

--- a/js/commands/SerialCommand.js
+++ b/js/commands/SerialCommand.js
@@ -130,7 +130,8 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 
                 //not trying to be secure here, just trying to be helpful.
                 if ((port.manufacturer && port.manufacturer.indexOf("Spark") >= 0) ||
-                    (port.pnpId && port.pnpId.indexOf("Spark_Core") >= 0)) {
+                    (port.pnpId && port.pnpId.indexOf("Spark_Core") >= 0) ||
+                     port.pnpId && port.pnpId.indexOf("VID_1D50") >= 0) {
                     cores.push(port);
                 }
             }

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "spark-cli",
     "description": "Simple Node commandline application for working with your Spark Cores and using the Spark Cloud",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "author": "David Middlecamp",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Add an additional check for the Spark USB Vendor ID: VID_1D50 in findcores

This allows the Spark to be found on PCs that can use the USB com port
without the Spark driver.
