### PR TITLE
spark config identify command

### DIFF
--- a/js/commands/ConfigCommand.js
+++ b/js/commands/ConfigCommand.js
@@ -102,7 +102,7 @@ ConfigCommand.prototype = extend(BaseCommand.prototype, {
         settings.override(group, name, value);
     },
     
-    identifyServer: function (profile) {
+    identifyServer: function () {
         console.log("Current profile: " + settings.profile);
         console.log("IP address: " + settings.apiUrl);
     },


### PR DESCRIPTION
There are a couple of users who got confused as to why their core was breathing cyan and connected to their own cloud but `spark list` showed no cores being online.

It turns out that the `spark config` command is useful but very often, they do not remember which profile they are currently on. Opened a similar issue to printout the current ip address but can't locate the github issue now..

I'm proposing to have a `spark config identify` kind of command to output the current profile being used and the data in the `.json` file.
