### PR TITLE
printout access token

### DIFF
--- a/js/commands/ConfigCommand.js
+++ b/js/commands/ConfigCommand.js
@@ -110,6 +110,7 @@ ConfigCommand.prototype = extend(BaseCommand.prototype, {
     identifyServer: function () {
         console.log("Current profile: " + settings.profile);
         console.log("Using API: " + settings.apiUrl);
+        console.log("Access token: " +  settings.access_token);
     },
 
     listConfigs: function() {


### PR DESCRIPTION
`spark config identify` will show the access token used as well for users wanting to quickly grab one for testing. 

Might be better to clean up this portion of code in future to list out all the parameters in the profile than to explicitly use `console.log` for each specific param!