### PR TITLE
make prompts exit gracefully when they're done

### DIFF
--- a/js/lib/prompts.js
+++ b/js/lib/prompts.js
@@ -60,6 +60,7 @@ var that = {
         var prompt = that.getPrompt();
         prompt.question(message, function (value) {
             dfd.resolve(value);
+            that.closePrompt();
         });
         return dfd.promise;
     },
@@ -79,6 +80,8 @@ var that = {
             else {
                 dfd.reject(value);
             }
+
+            that.closePrompt();
         });
         return dfd.promise;
     },
@@ -112,6 +115,7 @@ var that = {
             }
             else {
                 process.stdout.write("\n");
+                process.stdin.pause();
                 dfd.resolve(arr.join(''));
             }
         };


### PR DESCRIPTION
Currently promptDfd, askYesNoQuestion, and passPromptDfd do not exit
gracefully when we're done with them and require that upstream code that
calls them call process.exit() to actually end the process unless the
use types an End of Transmission character (^D).

promptDfd and askYesNoQuestion use a readline Interface and can be
gracefully closed with prompts.js' "closePrompt" method.

passPromptDfd does *not* use a readline Interface and requires that we
manually call stdin.pause() to close it gracefully.