### PR TITLE
Feature/access tokens

### DIFF
--- a/js/commands/AccessTokenCommands.js
+++ b/js/commands/AccessTokenCommands.js
@@ -55,7 +55,7 @@ AccessTokenCommands.prototype = extend(BaseCommand.prototype, {
     init: function () {
         this.addOption("list", this.listAccessTokens.bind(this), "List all access tokens for your account");
         this.addOption("revoke", this.revokeAccessToken.bind(this), "Revoke an access token");
-        //this.addOption("new", this.createAccessToken.bind(this), "Create a new access token");
+        this.addOption("new", this.createAccessToken.bind(this), "Create a new access token");
     },
 
     checkArguments: function (args) {
@@ -152,6 +152,35 @@ AccessTokenCommands.prototype = extend(BaseCommand.prototype, {
             function (err) {
                 console.log("there was an error deleting " + token + ":");
                 console.log("  " + err);
+            }
+        );
+        return;
+    },
+
+    createAccessToken: function (clientName) {
+
+        if (!clientName) {
+            clientName = "user";
+        }
+
+        var allDone = pipeline([
+            prompts.getCredentials,
+            function (creds) {
+                var api = new ApiClient(settings.apiUrl);
+                return api.createAccessToken(clientName, creds[0], creds[1]);
+            }
+        ]);
+
+        allDone.done(
+            function (result) {
+                var now_unix = Date.now();
+                var expires_unix = now_unix + (result.expires_in * 1000);
+                var expires_date = new Date(expires_unix);
+                console.log('New access token expires on ' + expires_date);
+                console.log('    ' + result.access_token);
+            },
+            function (err) {
+                console.log("there was an error creating a new access token: " + err);
             }
         );
         return;

--- a/js/commands/AccessTokenCommands.js
+++ b/js/commands/AccessTokenCommands.js
@@ -48,63 +48,63 @@ var AccessTokenCommands = function (cli, options) {
 util.inherits(AccessTokenCommands, BaseCommand);
 AccessTokenCommands.prototype = extend(BaseCommand.prototype, {
     options: null,
-	name: "token",
+    name: "token",
     description: "tools to help you manage access tokens on your account",
 
     init: function () {
         this.addOption("list", this.listAccessTokens.bind(this), "List all access tokens for your account");
-		//this.addOption("revoke", this.revokeAccessToken.bind(this), "Revoke an access token");
-		//this.addOption("new", this.createAccessToken.bind(this), "Create a new access token");
+        //this.addOption("revoke", this.revokeAccessToken.bind(this), "Revoke an access token");
+        //this.addOption("new", this.createAccessToken.bind(this), "Create a new access token");
     },
 
-	checkArguments: function (args) {
-		this.options = this.options || {};
+    checkArguments: function (args) {
+        this.options = this.options || {};
 
-		if (!this.options.force) {
-			this.options.force = utilities.tryParseArgs(args,
-				"--force",
-				null
-			);
-		}
-	},
+        if (!this.options.force) {
+            this.options.force = utilities.tryParseArgs(args,
+                "--force",
+                null
+            );
+        }
+    },
 
-	getAccessTokens: function (args) {
-		console.error("Checking with the cloud...");
-		var tmp = when.defer();
+    getAccessTokens: function (args) {
+        console.error("Checking with the cloud...");
+        var tmp = when.defer();
 
-		pipeline([
-			prompts.getCredentials,
-			function (creds) {
-				var api = new ApiClient(settings.apiUrl);
-				tmp.resolve(api.listTokens(creds[0], creds[1]));
-			}
-		]);
+        pipeline([
+            prompts.getCredentials,
+            function (creds) {
+                var api = new ApiClient(settings.apiUrl);
+                tmp.resolve(api.listTokens(creds[0], creds[1]));
+            }
+        ]);
 
-		return tmp.promise;
-	},
+        return tmp.promise;
+    },
 
-	listAccessTokens: function (args) {
+    listAccessTokens: function (args) {
 
-		when(this.getAccessTokens(args)).then(function (tokens) {
-			try {
-				var lines = [];
-				for (var i = 0; i < tokens.length; i++) {
-					// TODO: put a marker on settings.acccess_token
-					// TODO: sort by expiration date
-					token = tokens[i];
-					lines.push('Token: ' + token.token);
-					lines.push('  Expires At: ' + token.expires_at);
-					lines.push('  Client:     ' + token.client);
-				}
-				console.log(lines.join("\n"));
-			}
-			catch (ex) {
-				console.error("Error during list " + ex);
-			}
-		}, function(err) {
-			console.log("Please make sure you're online and logged in.");
-		});
-	},
+        when(this.getAccessTokens(args)).then(function (tokens) {
+            try {
+                var lines = [];
+                for (var i = 0; i < tokens.length; i++) {
+                    // TODO: put a marker on settings.acccess_token
+                    // TODO: sort by expiration date
+                    token = tokens[i];
+                    lines.push('Token: ' + token.token);
+                    lines.push('  Expires At: ' + token.expires_at);
+                    lines.push('  Client:     ' + token.client);
+                }
+                console.log(lines.join("\n"));
+            }
+            catch (ex) {
+                console.error("Error during list " + ex);
+            }
+        }, function(err) {
+            console.log("Please make sure you're online and logged in.");
+        });
+    },
 
     _: null
 });

--- a/js/commands/AccessTokenCommands.js
+++ b/js/commands/AccessTokenCommands.js
@@ -68,24 +68,21 @@ AccessTokenCommands.prototype = extend(BaseCommand.prototype, {
         }
     },
 
-    getAccessTokens: function (args) {
+    getAccessTokens: function () {
         console.error("Checking with the cloud...");
-        var tmp = when.defer();
 
-        pipeline([
+        return pipeline([
             prompts.getCredentials,
             function (creds) {
                 var api = new ApiClient(settings.apiUrl);
-                tmp.resolve(api.listTokens(creds[0], creds[1]));
+                return api.listTokens(creds[0], creds[1]);
             }
         ]);
-
-        return tmp.promise;
     },
 
-    listAccessTokens: function (args) {
+    listAccessTokens: function () {
 
-        when(this.getAccessTokens(args)).then(function (tokens) {
+        this.getAccessTokens().then(function (tokens) {
             try {
                 var lines = [];
                 for (var i = 0; i < tokens.length; i++) {

--- a/js/commands/AccessTokenCommands.js
+++ b/js/commands/AccessTokenCommands.js
@@ -1,0 +1,112 @@
+/**
+ ******************************************************************************
+ * @file    js/commands/AccessTokenCommands.js
+ * @author  Kyle Marsh (kyle@cs.hmc.edu)
+ * @source  https://github.com/spark/spark-cli
+ * @version V1.0.0
+ * @date    14-February-2014
+ * @brief   Access Token commands module
+ ******************************************************************************
+  Copyright (c) 2014 Spark Labs, Inc.  All rights reserved.
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this program; if not, see <http://www.gnu.org/licenses/>.
+  ******************************************************************************
+ */
+
+var when = require('when');
+var sequence = require('when/sequence');
+var pipeline = require('when/pipeline');
+
+var extend = require('xtend');
+var fs = require('fs');
+var path = require('path');
+var readline = require('readline');
+var util = require('util');
+
+var ApiClient = require('../lib/ApiClient.js');
+var BaseCommand = require("./BaseCommand.js");
+var prompts = require('../lib/prompts.js');
+var settings = require('../settings.js');
+
+var AccessTokenCommands = function (cli, options) {
+    AccessTokenCommands.super_.call(this, cli, options);
+    this.options = extend({}, this.options, options);
+
+    this.init();
+};
+util.inherits(AccessTokenCommands, BaseCommand);
+AccessTokenCommands.prototype = extend(BaseCommand.prototype, {
+    options: null,
+	name: "token",
+    description: "tools to help you manage access tokens on your account",
+
+    init: function () {
+        this.addOption("list", this.listAccessTokens.bind(this), "List all access tokens for your account");
+		//this.addOption("revoke", this.revokeAccessToken.bind(this), "Revoke an access token");
+		//this.addOption("new", this.createAccessToken.bind(this), "Create a new access token");
+    },
+
+	checkArguments: function (args) {
+		this.options = this.options || {};
+
+		if (!this.options.force) {
+			this.options.force = utilities.tryParseArgs(args,
+				"--force",
+				null
+			);
+		}
+	},
+
+	getAccessTokens: function (args) {
+		console.error("Checking with the cloud...");
+		var tmp = when.defer();
+
+		pipeline([
+			prompts.getCredentials,
+			function (creds) {
+				var api = new ApiClient(settings.apiUrl);
+				tmp.resolve(api.listTokens(creds[0], creds[1]));
+			}
+		]);
+
+		return tmp.promise;
+	},
+
+	listAccessTokens: function (args) {
+
+		when(this.getAccessTokens(args)).then(function (tokens) {
+			try {
+				var lines = [];
+				for (var i = 0; i < tokens.length; i++) {
+					// TODO: put a marker on settings.acccess_token
+					// TODO: sort by expiration date
+					token = tokens[i];
+					lines.push('Token: ' + token.token);
+					lines.push('  Expires At: ' + token.expires_at);
+					lines.push('  Client:     ' + token.client);
+				}
+				console.log(lines.join("\n"));
+			}
+			catch (ex) {
+				console.error("Error during list " + ex);
+			}
+		}, function(err) {
+			console.log("Please make sure you're online and logged in.");
+		});
+	},
+
+    _: null
+});
+
+module.exports = AccessTokenCommands;

--- a/js/lib/ApiClient.js
+++ b/js/lib/ApiClient.js
@@ -163,7 +163,7 @@ ApiClient.prototype = {
         return dfd.promise;
     },
 
-	//DELETE /v1/access_tokens/{ACCESS_TOKEN}
+    //DELETE /v1/access_tokens/{ACCESS_TOKEN}
     removeAccessToken: function (username, password, access_token) {
         console.log("removing access_token " + access_token);
 
@@ -199,7 +199,7 @@ ApiClient.prototype = {
         return dfd.promise;
     },
 
-	//GET /v1/access_tokens
+    //GET /v1/access_tokens
     listTokens: function (username, password) {
         var that = this;
         var dfd = when.defer();

--- a/js/lib/ApiClient.js
+++ b/js/lib/ApiClient.js
@@ -163,6 +163,7 @@ ApiClient.prototype = {
         return dfd.promise;
     },
 
+	//DELETE /v1/access_tokens/{ACCESS_TOKEN}
     removeAccessToken: function (username, password, access_token) {
         console.log("removing access_token " + access_token);
 
@@ -192,6 +193,33 @@ ApiClient.prototype = {
             else {
                 //huh?
                 dfd.reject(body);
+            }
+        });
+
+        return dfd.promise;
+    },
+
+	//GET /v1/access_tokens
+    listTokens: function (username, password) {
+        var that = this;
+        var dfd = when.defer();
+        request({
+            uri: this.baseUrl + "/v1/access_tokens",
+            method: "GET",
+            auth: {
+                username: username,
+                password: password
+            },
+            json: true
+        }, function (error, response, body) {
+            that.hasBadToken(error, body);
+
+            if (error || body.error) {
+                console.error("listTokens got error: ", error || body.error);
+                dfd.reject(error || body.error);
+            }
+            else {
+                dfd.resolve(body);
             }
         });
 

--- a/js/lib/ApiClient.js
+++ b/js/lib/ApiClient.js
@@ -130,37 +130,14 @@ ApiClient.prototype = {
     login: function (client_id, user, pass) {
         var that = this;
 
-        var dfd = when.defer();
-        request({
-            uri: this.baseUrl + "/oauth/token",
-            method: "POST",
-            form: {
-                username: user,
-                password: pass,
-                grant_type: 'password',
-                client_id: client_id,
-                client_secret: "client_secret_here"
-            },
-            json: true
-        }, function (error, response, body) {
-            that.hasBadToken(error, body);
-
-            if (body && body.access_token) {
-                console.log("Got an access token! " + body.access_token);
-                that._access_token = body.access_token;
-                dfd.resolve(that._access_token);
-            }
-            else if (body) {
-                //console.log("login got ", body.error);
-                dfd.reject("Login Failed");
-            }
-            else {
-                console.error("login error: ", error);
-                dfd.reject("Login Failed: " + error);
-            }
+        return this.createAccessToken(client_id, user, pass).then(function(resp) {
+            console.log("Got an access token! " + resp.access_token);
+            that._access_token = resp.access_token;
+            return that._access_token;
+        }).catch(function (err) {
+            console.error("login error: ", err);
+            return("Login Failed: " + err);
         });
-
-        return dfd.promise;
     },
 
     //GET /oauth/token

--- a/js/lib/ApiClient.js
+++ b/js/lib/ApiClient.js
@@ -202,28 +202,25 @@ ApiClient.prototype = {
     //GET /v1/access_tokens
     listTokens: function (username, password) {
         var that = this;
-        var dfd = when.defer();
-        request({
-            uri: this.baseUrl + "/v1/access_tokens",
-            method: "GET",
-            auth: {
-                username: username,
-                password: password
-            },
-            json: true
-        }, function (error, response, body) {
-            that.hasBadToken(error, body);
-
-            if (error || body.error) {
-                console.error("listTokens got error: ", error || body.error);
-                dfd.reject(error || body.error);
-            }
-            else {
-                dfd.resolve(body);
-            }
+        return when.promise(function (resolve, reject, notify) {
+            request({
+                uri: that.baseUrl + "/v1/access_tokens",
+                method: "GET",
+                auth: {
+                    username: username,
+                    password: password
+                },
+                json: true
+            }, function (error, response, body) {
+                if (error || (body['ok'] == false)) {
+                    console.error("listTokens got error: ", error || body.errors);
+                    reject(error || body.errors);
+                }
+                else {
+                    resolve(body);
+                }
+            });
         });
-
-        return dfd.promise;
     },
 
 

--- a/js/lib/ApiClient.js
+++ b/js/lib/ApiClient.js
@@ -187,8 +187,8 @@ ApiClient.prototype = {
             if (body && body.ok) {
                 dfd.resolve(body);
             }
-            else if (body && body.error) {
-                dfd.reject(body.error);
+            else if (body && (body.error || body.errors)) {
+                dfd.reject(body.error || body.errors);
             }
             else {
                 //huh?

--- a/js/lib/ApiClient.js
+++ b/js/lib/ApiClient.js
@@ -163,6 +163,35 @@ ApiClient.prototype = {
         return dfd.promise;
     },
 
+    //GET /oauth/token
+    createAccessToken: function (client_id, username, password) {
+        var that = this;
+        return when.promise(function (resolve, reject, notify) {
+            request({
+                uri: that.baseUrl + "/oauth/token",
+                method: "POST",
+                form: {
+                    username: username,
+                    password: password,
+                    grant_type: 'password',
+                    client_id: client_id,
+                    client_secret: "client_secret_here"
+                },
+                json: true
+            }, function (error, response, body) {
+                if (error || body.error) {
+                    console.error(
+                        "Could not get new access token: ",
+                        error || body.error_description
+                    );
+                    reject(error || body.error);
+                } else {
+                    resolve(body);
+                }
+            });
+        });
+    },
+
     //DELETE /v1/access_tokens/{ACCESS_TOKEN}
     removeAccessToken: function (username, password, access_token) {
         console.log("removing access_token " + access_token);


### PR DESCRIPTION
Implements a new set of commands to manage access tokens: can list, create, and revoke tokens. All these commands require the username and password to be reentered.

Listing tokens sorts by expiration date (longest-lived tokens first), indicates expired tokens with (expired) next to the client name, and indicates the token that this copy of the CLI is using with an *.

Revoking tokens can take multiple tokens as arguments and will only ask you for your credentials once before revoking all the specified tokens. Revoking the CLI's active token will fail unless you use "--force" in your arguments.

Creating a new token will look for the client name as an argument or default to "user".

Sample output from all three commands:

    > spark token list
    Checking with the cloud...
    Could I please have an email address?  me@domain.com
    and a password?  *******
    spark-cli*
     Token:      abcdef0987654321
     Expires At: 2015-03-22T02:45:32.037Z

    spark-ide (expired)
     Token:      1234567890abcdef
     Expires At: 2014-12-20T22:36:22.704Z
    >
    > spark token revoke abcdef0987654321 34567890deadbeef
    WARNING: abcdef0987654321 is this CLI's access token
    use --force to delete it
    >
    > spark token revoke --force abcdef0987654321 34567890deadbeef
    WARNING: abcdef0987654321 is this CLI's access token
    **forcing**
    Could I please have an email address?  me@domain.com
    and a password?  *******
    removing access_token abcdef0987654321
    removing access_token 34567890deadbeef
    successfully deleted abcdef0987654321
    error revoking asdf: "invalid_request"
    >
    > spark token new client-name
    Could I please have an email address?  me@domain.com
    and a password?  *******
    New access token expires on Sat Mar 21 2015 15:48:00 GMT-0700 (PDT)
        a0b9c8d7e6f54321

All three of these commands rely on the fix in https://github.com/spark/spark-cli/pull/123 to exit cleanly -- without that patch they will continue waiting for input after the command completes until passed an End Of Transmission character (^D) or terminated.