### PR TITLE
bump serialport to 1.5.0

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -19,7 +19,7 @@
     "hogan.js": "~2.0.0",
     "moment": "*",
     "request": "2.46.0",
-    "serialport": "1.4.5",
+    "serialport": "1.5.0",
     "when": "*",
     "xtend": "*",
     "node-wifiscanner": "*"


### PR DESCRIPTION
- allows windows platform to install **spark-cli** without requiring Visual Studio for installation
- binaries available for linux and Mac OSx platform as well

*forming a small testing group of windows variant to test installation of this new version to verify that is fixes the issue would be ideal*

fix for https://github.com/spark/spark-cli/pull/137