### PR TITLE
Turn help requests for unknown commands into requests for more help.

### DIFF
--- a/js/commands/BaseCommand.js
+++ b/js/commands/BaseCommand.js
@@ -102,14 +102,7 @@ BaseCommand.prototype = {
             {
                 args = [ args ];
             }
-            // prevent help requests for non-existent commands from blowing the stack
-            if(this.name == "help" && args.length > 0) {
-                if(!this.cli._commandsMap[args[0]] && !this.cli.commandsByName[args[0]]) {
 
-                    console.log("Sorry, no help available for '%s'.\n", args[0]);
-                    args = [ ];
-                }
-            }
             return cmdFn.apply(this, args);
         }
         else {

--- a/js/commands/BaseCommand.js
+++ b/js/commands/BaseCommand.js
@@ -102,7 +102,14 @@ BaseCommand.prototype = {
             {
                 args = [ args ];
             }
+            // prevent help requests for non-existent commands from blowing the stack
+            if(this.name == "help" && args.length > 0) {
+                if(!this.cli._commandsMap[args[0]] && !this.cli.commandsByName[args[0]]) {
 
+                    console.log("Sorry, no help available for '%s'.\n", args[0]);
+                    args = [ "help" ];
+                }
+            }
             return cmdFn.apply(this, args);
         }
         else {

--- a/js/commands/BaseCommand.js
+++ b/js/commands/BaseCommand.js
@@ -107,7 +107,7 @@ BaseCommand.prototype = {
                 if(!this.cli._commandsMap[args[0]] && !this.cli.commandsByName[args[0]]) {
 
                     console.log("Sorry, no help available for '%s'.\n", args[0]);
-                    args = [ "help" ];
+                    args = [ ];
                 }
             }
             return cmdFn.apply(this, args);

--- a/js/commands/HelpCommand.js
+++ b/js/commands/HelpCommand.js
@@ -72,7 +72,7 @@ HelpCommand.prototype = extend(BaseCommand.prototype, {
 
         var command = this.cli.findCommand(name);
         if (!command) {
-            this.listCommandsSwitch(name);
+            this.listCommandsSwitch();
             return;
         }
 

--- a/js/commands/HelpCommand.js
+++ b/js/commands/HelpCommand.js
@@ -72,6 +72,7 @@ HelpCommand.prototype = extend(BaseCommand.prototype, {
 
         var command = this.cli.findCommand(name);
         if (!command) {
+            console.log("Sorry, no help available for '%s'", name);
             this.listCommandsSwitch();
             return;
         }


### PR DESCRIPTION
This fixes `RangeError: Maximum call stack size exceeded` when calling help on unknown commands, and instead shows the output of `spark help help`. 

@dmiddlecamp not sure whether it's better to just show output of `spark help` instead?

Fixes #132