### PR TITLE
Print-out account + rename to "re-enter"

### DIFF
--- a/commands/AccessTokenCommands.js
+++ b/commands/AccessTokenCommands.js
@@ -64,7 +64,8 @@ AccessTokenCommands.prototype = extend(BaseCommand.prototype, {
 			return sequence([
 				function () { return settings.username },
 				function () {
-					return prompts.passPromptDfd("Please reenter your password:  ");
+					console.log("Using account: " + settings.username);
+					return prompts.passPromptDfd("Please re-enter your password:  ");
 				}
 			]);
 		} else {

--- a/commands/AccessTokenCommands.js
+++ b/commands/AccessTokenCommands.js
@@ -69,6 +69,7 @@ AccessTokenCommands.prototype = extend(BaseCommand.prototype, {
 				}
 			]);
 		} else {
+			console.log("Seems like you have not logged in...Let's do that!");
 			return prompts.getCredentials();
 		}
 	},


### PR DESCRIPTION
This will give more clarity to the user in terms of being reminded which email address **Spark-cli** is currently on.

Minor word fix reenter --> re-enter