### PR TITLE
Improve core list formatting

### DIFF
--- a/commands/CloudCommands.js
+++ b/commands/CloudCommands.js
@@ -562,8 +562,8 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 					var numVars = utilities.countHashItems(core.variables);
 					var numFuncs = utilities.countHashItems(core.functions);
 
-					var status = core.name + " (" + core.id + ") is ";
-					status += (core.connected) ? "online" : "offline";
+					var status = (core.connected) ? "online " : "offline";
+					status += " - " + core.name + " (" + core.id + ")";
 					lines.push(status);
 
 					formatVariables(core.variables, lines);


### PR DESCRIPTION
Not the best but slightly improved: 

```
Checking with the cloud...
Retrieving cores... (this might take a few seconds)
offline - black (xxxx)
offline - kennethlimcp (xxxx)
offline - locker (xxx)
offline - photon-1 (xxx)
offline - photon-2 (xx)
offline - plumber_laser (xxx)
offline - torch (xxx)
offline - ufl (xxx)
```