### PR TITLE
Webhook take in correct params

### DIFF
--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -105,13 +105,13 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
         return this.createHook(eventName, url, coreID, "GET");
     },
 
-    createHook: function (eventName, url, coreID) {
+    createHook: function (eventName, url, coreID, requestType) {
         var api = new ApiClient(settings.apiUrl, settings.access_token);
         if (!api.ready()) {
             return -1;
         }
 
-        if (!eventName && !url && !coreID) {
+        if (!eventName && !url && !coreID && !requestType) {
             var help = this.cli.getCommandModule("help");
             return help.helpCommand(this.name, "create");
         }
@@ -148,9 +148,11 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
         }
 
 		//TODO: clean this up more?
-		data.event = data.eventName;
+		data.event = eventName;
+		data.url = url
 		data.deviceid = coreID;
 		data.access_token = api._access_token;
+		data.requestType = requestType;
 
 		api.createWebhookWithObj(data);
 


### PR DESCRIPTION
Tested with:

- `webhook GET get_weather http://w1.weather.gov/xml/current_obs/KMSP.xml`

```sh
Sending webhook request  { uri: 'https://api.spark.io/v1/webhooks',
  method: 'POST',
  json: true,
  form: 
   { event: 'get_weather',
     url: 'http://w1.weather.gov/xml/current_obs/KMSP.xml',
     deviceid: undefined,
     access_token: 'xxxxxxx',
     requestType: 'GET' } }
Successfully created webhook!
```
- `webhook POST get_weather http://w1.weather.gov/xml/current_obs/KMSP.xml`

```sh
Sending webhook request  { uri: 'https://api.spark.io/v1/webhooks',
  method: 'POST',
  json: true,
  form: 
   { event: 'get_weather',
     url: 'http://w1.weather.gov/xml/current_obs/KMSP.xml',
     deviceid: undefined,
     access_token: 'xxxx',
     requestType: 'POST' } }
Successfully created webhook!

```

- `webhook create test.json` 

```sh
Sending webhook request  { uri: 'https://api.spark.io/v1/webhooks',
  method: 'POST',
  json: true,
  form: 
   { eventName: 'librato_',
     url: 'https://metrics-api.librato.com/v1/metrics',
     requestType: 'POST',
     event: 'librato_',
     deviceid: undefined,
     access_token: '450ddb8ea93da3fcd9ec8ab4a75ed56d7aa6b246' } }
Successfully created webhook!
```

All worked well and parsed the correct parameters.