### PR TITLE
Stop telling users to run `sudo brew`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ Here are some great tutorials on the community for full installs:
 [Installing on Windows](https://community.spark.io/t/tutorial-spark-cli-on-windows-06-may-2014/3112)
 
 #### Installing on Mac OS X: 
-Rather than installing these packages from source, and instead of using MacPorts, it is relatively straightforward to use [Homebrew](http://brew.sh) to install `dfu-util`, `openssl`, and `libusb` (required for dfu-util). Once you have installed `brew` the basic command for each is `brew install dfu-util` . For the final step of `openssl` you will need to do `sudo brew install openssl` and enter your admin password.
+Rather than installing these packages from source, and instead of using MacPorts, it is relatively straightforward to use [Homebrew](http://brew.sh) to install `dfu-util` and `openssl`:
+
+```sh
+brew install dfu-util openssl
+```
 
 Upgrading
 ---------------------------


### PR DESCRIPTION
It's not necessary and will ultimately cause users grief. We don't support it.

Also, libusb will be installed as a dependency of dfu-util, so users don't need to do so manually.