### PR TITLE
Remove # when listing webhook ids

### DIFF
--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -187,7 +187,7 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
                     var hook = hooks[i];
                     var line = [
                         "    ", (i+1),
-                        ".) Hook #" + hook.id + " is watching for ",
+                        ".) Hook id " + hook.id + " is watching for ",
                         "\""+hook.event+"\"",
 
                         "\n       ", " and posting to: " + hook.url,


### PR DESCRIPTION
As a user I didn't know if the # was part of the webhook ID or not. (Actually I first thought that the 1.) on the left side was the hook id)

When I double-click on the ID to select it in the terminal to copy it and paste it after `particle webhook delete` I get an error because the # was selected as part of the same word. I have to carefully select all characters except the first # when copying the webhook id.

This change makes it obvious which part is the ID and makes it easier to copy so hooks can be deleted.